### PR TITLE
added message size limit update to tasks

### DIFF
--- a/ansible/roles/email-server-config/tasks/main.yml
+++ b/ansible/roles/email-server-config/tasks/main.yml
@@ -40,6 +40,8 @@
       value: "{{ postfix_smtpd_milters }}"
     - name: non_smtpd_milters
       value: "{{ postfix_non_smtpd_milters }}"
+    - name: message_size_limit
+      value: "{{ postfix_message_size_limit }}"
 
 - name: Update main.cf Postfix configuration without comment entry
   lineinfile:


### PR DESCRIPTION
New limit was only present in defaults, not tasks, so was not being applied on rebuild.